### PR TITLE
Added client_config block to override Provider config.

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,11 +46,12 @@ The reason behind every resources and data sources are stated as below:
 
 - **st-gcp_load_balancer_backend_services**
 
-  The load balancer backend services on Google Cloud do not support tagging, therefore
-  backend service's description is used as tags with the format
-  `TagKey1:TagValue1|TagKey2:TagValue2`, where the character `|` is used as string
-  delimiter. Output will also convert description string to map if all are matched.
+  - The load balancer backend services on Google Cloud do not support tagging, therefore
+    backend service's description is used as tags with the format
+    `TagKey1:TagValue1|TagKey2:TagValue2`, where the character `|` is used as string
+    delimiter. Output will also convert description string to map if all are matched.
 
+  - Added client_config block to allow overriding the Provider configuration.
 
 References
 ----------

--- a/docs/data-sources/load_balancer_backend_services.md
+++ b/docs/data-sources/load_balancer_backend_services.md
@@ -28,12 +28,22 @@ data "st-gcp_load_balancer_backend_services" "def" {
 
 ### Optional
 
+- `client_config` (Block, Optional) Config to override default client created in Provider. This block will not be recorded in state file. (see [below for nested schema](#nestedblock--client_config))
 - `name` (String) Name of backend service to be filtered.
 - `tags` (Map of String) Tags of backend service to be filtered.
 
 ### Read-Only
 
 - `items` (Attributes List) List of queried load balancer backend services. (see [below for nested schema](#nestedatt--items))
+
+<a id="nestedblock--client_config"></a>
+### Nested Schema for `client_config`
+
+Optional:
+
+- `credentials` (String, Sensitive) The credentials of service account in JSON format  Default to use credentials configured in the provider.
+- `project` (String) Project Name for Google Cloud API. Default to use project configured in the provider.
+
 
 <a id="nestedatt--items"></a>
 ### Nested Schema for `items`


### PR DESCRIPTION
The client_config block will override the Provider config, with any of the arguments specified in data sources: 
```
{
  project: string
  credentials: string
}
```

Affected Data Sources:
- `st-gcp_load_balancer_backend_services`