### PR TITLE
[Hotfix] resp.Body.Close()

### DIFF
--- a/gcp/resource_acme_eab.go
+++ b/gcp/resource_acme_eab.go
@@ -190,7 +190,6 @@ func createEabCred(ctx context.Context, s *acmeEabState, credentialsJSON []byte,
 		} else {
 			resp, err = conf.Client(context.Background()).Post(api, "application/json", nil)
 		}
-		defer resp.Body.Close()
 
 		if err != nil {
 			errMsg := err.Error()
@@ -218,6 +217,8 @@ func createEabCred(ctx context.Context, s *acmeEabState, credentialsJSON []byte,
 	if resp.StatusCode != http.StatusOK {
 		return fmt.Errorf("url:" + api + ", error:" + string(body))
 	}
+
+	resp.Body.Close()
 
 	var eab externalAccountKeyResp
 	if err = json.Unmarshal(body, &eab); err != nil {


### PR DESCRIPTION
![image](https://github.com/myklst/terraform-provider-st-gcp/assets/58868419/d8cfb11a-47a6-4e47-9129-a521c166b3f2)

response body closed before io.ReadAll(resp.Body) 